### PR TITLE
Fix the doc string for "activate" command and its related help message

### DIFF
--- a/src/pdm_venv/commands/activate.py
+++ b/src/pdm_venv/commands/activate.py
@@ -12,7 +12,7 @@ from pdm_venv.utils import BIN_DIR, iter_venvs
 
 
 class ActivateCommand(BaseCommand):
-    """List all virtualenvs associated with this project"""
+    """Activate the virtualenv with the given name"""
 
     arguments = [verbose_option]
 


### PR DESCRIPTION
Fix the doc string for "activate" command and its related help message